### PR TITLE
verify bool return value

### DIFF
--- a/provider_test.go
+++ b/provider_test.go
@@ -42,7 +42,7 @@ func TestProvider_BooleanEvaluation(t *testing.T) {
 					Key:        "bool-flag",
 					DistinctId: "12345",
 				},
-				res: "true",
+				res: true,
 			},
 			res: openfeature.BooleanEvaluationDetails{
 				Value: true,
@@ -67,16 +67,13 @@ func TestProvider_BooleanEvaluation(t *testing.T) {
 				},
 				res: false,
 			},
-			err: true,
 			res: openfeature.BooleanEvaluationDetails{
 				Value: false,
 				EvaluationDetails: openfeature.EvaluationDetails{
 					FlagKey:  "bool-flag",
 					FlagType: openfeature.Boolean,
 					ResolutionDetail: openfeature.ResolutionDetail{
-						Reason:       openfeature.ErrorReason,
-						ErrorCode:    openfeature.FlagNotFoundCode,
-						ErrorMessage: `"bool-flag" not found`,
+						Reason:       openfeature.TargetingMatchReason,
 						FlagMetadata: openfeature.FlagMetadata{},
 					},
 				},


### PR DESCRIPTION
# Description

Boolean flag values are handled special in the current PostHog SDK implementation.

When a feature flag is not found, the returned value will be `false`. However, for boolean flag values, the returned value will also be a boolean, either `true` or `false` depending on the flag resolution.
Since we cannot distinguish the case if the flag is found or not for boolean values, the explicit error is removed from the boolean flag value. This way we avoid too many false-negatives.

